### PR TITLE
Relax elixir version dependency to >= 1.10

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Ecto.DevLogger.MixProject do
     [
       app: :ecto_dev_logger,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       description: "An alternative Ecto logger for development",
       package: package(),


### PR DESCRIPTION
@fuelen! Already loving this project; it's making psql tuning and debugging a far nicer experience, especially where UUIDs are concerned.

This PR relaxes the elixir dependency for the project to allow for versions greater than or equal to `1.10`, as it does not appear to depend on any of the new APIs in `1.12`, but was logging a version warning on a project.

I tested that I was able to build the package using 10.10.2 and 10.12.3, but we may be able to go further back than 10.10, if that's desired. Thanks again for a great library!