### PR TITLE
Add Support For Tds Adapter

### DIFF
--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -43,6 +43,7 @@ defmodule Ecto.DevLogger do
     unless oban_query?(metadata) do
       query_string = String.Chars.to_string(metadata.query)
       color = sql_color(query_string)
+      repo_adapter = metadata[:repo].__adapter__()
 
       query_string =
         metadata.params
@@ -55,8 +56,6 @@ defmodule Ecto.DevLogger do
               stringify_ecto_params(binding, :root),
               apply(IO.ANSI, color, [])
             ])
-
-          repo_adapter = metadata[:repo].__adapter__()
 
           replace_params(repo_adapter, query, index, replacement)
         end)

--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -56,7 +56,9 @@ defmodule Ecto.DevLogger do
               apply(IO.ANSI, color, [])
             ])
 
-          String.replace(query, "$#{index}", replacement)
+          repo_adapter = metadata[:repo].__adapter__()
+
+          replace_params(repo_adapter, query, index, replacement)
         end)
 
       Logger.debug(
@@ -181,5 +183,13 @@ defmodule Ecto.DevLogger do
 
   defp stringify_ecto_params(%{} = map, :child) when not is_struct(map) do
     Jason.encode!(map)
+  end
+
+  defp replace_params(Ecto.Adapters.Tds, query, index, replacement) do
+    String.replace(query, "@#{index}", replacement)
+  end
+
+  defp replace_params(_adapter, query, index, replacement) do
+    String.replace(query, "$#{index}", replacement)
   end
 end


### PR DESCRIPTION
Hey! Great library. We use SQL Server at my job and so I wanted to add support for the Ecto.Adapters.Tds params which use the `@` scalar variable declaration.

I figured adding tests for this may be tricky since you would most likely need a docker instance setup with the MSSQL Docker image (`mcr.microsoft.com/mssql/server:2019-latest`), and you may not want that in your tests without full docker support on the PostgreSQL DB as well. Let me know your thoughts there.

Garrett