### PR TITLE
Allow logging for Ecto.ParameterizedType tuples

### DIFF
--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -168,14 +168,17 @@ defmodule Ecto.DevLogger do
     "'#{stringify_ecto_params(map, :child)}'"
   end
 
-  defp stringify_ecto_params(composite, :root) when is_tuple(composite) do
+  defp stringify_ecto_params(composite, level) when is_tuple(composite) do
     values =
       composite
       |> Tuple.to_list()
       |> Enum.map(&stringify_ecto_params(&1, :child))
       |> Enum.join(", ")
 
-    "'(#{values})'"
+    case level do
+      :root -> "'(#{values})'"
+      :child -> "\"(#{values})\""
+    end
   end
 
   defp stringify_ecto_params(%Date{} = date, :child) do

--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -168,6 +168,16 @@ defmodule Ecto.DevLogger do
     "'#{stringify_ecto_params(map, :child)}'"
   end
 
+  defp stringify_ecto_params(composite, :root) when is_tuple(composite) do
+    values =
+      composite
+      |> Tuple.to_list()
+      |> Enum.map(&stringify_ecto_params(&1, :child))
+      |> Enum.join(", ")
+
+    "'(#{values})'"
+  end
+
   defp stringify_ecto_params(%Date{} = date, :child) do
     to_string(date)
   end

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -17,7 +17,9 @@ defmodule Ecto.DevLoggerTest do
     def init(_opts), do: %{}
 
     def cast(_data, _params), do: {:ok, nil}
-    def load(_data, _loader, _params), do: {:ok, nil}
+
+    def load(nil, _loader, _params), do: {:ok, nil}
+    def load({currency, value}, _loader, _params), do: {:ok, %Money{currency: currency, value: value}}
 
     def dump(nil, _dumper, _params), do: {:ok, nil}
     def dump(data, _dumper, _params), do: {:ok, {data.currency, data.value}}
@@ -38,9 +40,10 @@ defmodule Ecto.DevLoggerTest do
       field(:decimal, :decimal)
       field(:date, :date)
       field(:array_of_strings, {:array, :string})
+      field(:money, Money.Ecto.Type)
+      field(:multi_money, {:array, Money.Ecto.Type})
       field(:datetime, :utc_datetime_usec)
       field(:naive_datetime, :naive_datetime_usec)
-      field(:money, Money.Ecto.Type)
     end
   end
 
@@ -65,6 +68,7 @@ defmodule Ecto.DevLoggerTest do
       date date,
       array_of_strings text[],
       money money_type,
+      multi_money money_type[],
       datetime timestamp without time zone NOT NULL,
       naive_datetime timestamp without time zone NOT NULL
     )
@@ -92,6 +96,7 @@ defmodule Ecto.DevLoggerTest do
         date: Date.utc_today(),
         array_of_strings: ["hello", "world"],
         money: %Money{currency: "USD", value: 390},
+        multi_money: [%Money{currency: "USD", value: 230}, %Money{currency: "USD", value: 180}],
         datetime: DateTime.utc_now(),
         naive_datetime: NaiveDateTime.utc_now()
       })

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -12,7 +12,7 @@ defmodule Ecto.DevLoggerTest do
   defmodule Money.Ecto.Type do
     use Ecto.ParameterizedType
 
-    def type(_params), do: :composite_type
+    def type(_params), do: :money_type
 
     def init(_opts), do: %{}
 

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -26,6 +26,8 @@ defmodule Ecto.DevLoggerTest do
     Repo.__adapter__().storage_up(config())
     {:ok, _} = Repo.start_link(config())
 
+    Repo.query!("CREATE EXTENSION \"pgcrypto\";")
+
     Repo.query!("""
     CREATE TABLE posts (
       id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),


### PR DESCRIPTION
First of all, thank you so much for this lib, it's so handy and awesome.

#### Context

I have multiple `Ecto.ParameterizedType` using Postgres types in the DB that can't be logged, raising the error below:

```elixir
21:14:03.451 [error] Handler "ecto.dev_logger" has failed and has been detached. Class=:error
Reason=:function_clause
Stacktrace=[
  {Ecto.DevLogger, :stringify_ecto_params, [{"BRL", #Decimal<0>}, :root],
   [file: 'lib/ecto/dev_logger.ex', line: 137]},
  {Ecto.DevLogger, :"-telemetry_handler/4-fun-0-", 4,
   [file: 'lib/ecto/dev_logger.ex', line: 56]},
  {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 2356]},
  {Ecto.DevLogger, :telemetry_handler, 4,
   [file: 'lib/ecto/dev_logger.ex', line: 52]},
  {:telemetry, :"-execute/3-fun-0-", 4,
   [
     file: '/Users/myuser/code/myapp/api/deps/telemetry/src/telemetry.erl',
     line: 135
   ]},
  {:lists, :foreach, 2, [file: 'lists.erl', line: 1342]},
  {Ecto.Adapters.SQL, :log, 4, [file: 'lib/ecto/adapters/sql.ex', line: 927]},
  {DBConnection, :log, 5, [file: 'lib/db_connection.ex', line: 1479]},
  {Postgrex, :query, 4, [file: 'lib/postgrex.ex', line: 312]},
  {Ecto.Adapters.SQL, :struct, 10,
   [file: 'lib/ecto/adapters/sql.ex', line: 802]},
  {Ecto.Repo.Schema, :apply, 4, [file: 'lib/ecto/repo/schema.ex', line: 744]},
  {Ecto.Repo.Schema, :"-do_insert/4-fun-1-", 15,
   [file: 'lib/ecto/repo/schema.ex', line: 367]},
  {Ecto.Repo.Schema, :"-wrap_in_transaction/6-fun-0-", 3,
   [file: 'lib/ecto/repo/schema.ex', line: 985]},
  {Ecto.Adapters.SQL, :"-checkout_or_transaction/4-fun-0-", 3,
   [file: 'lib/ecto/adapters/sql.ex', line: 1021]},
  {DBConnection, :run_transaction, 4,
   [file: 'lib/db_connection.ex', line: 1531]},
  {Ecto.Repo.Schema, :insert!, 4, [file: 'lib/ecto/repo/schema.ex', line: 269]},
  {MyApp.Transactions.SearchTest, :__ex_unit_setup_1, 1,
   [file: 'test/myapp/transactions/search_test.exs', line: 10]},
  {MyApp.Transactions.SearchTest, :__ex_unit__, 2,
   [file: 'test/myapp/transactions/search_test.exs', line: 1]},
  {ExUnit.Runner, :exec_test_setup, 2,
   [file: 'lib/ex_unit/runner.ex', line: 495]},
  {ExUnit.Runner, :"-spawn_test_monitor/4-fun-0-", 2,
   [file: 'lib/ex_unit/runner.ex', line: 454]}
]
```

#### Changes

Since `ParameterizedTypes` are dumped to the DB as tuples, this PR will allow more complex `Ecto.ParameterizedType` to be logged as well.

```sql
[debug] QUERY OK db=9.0ms
INSERT INTO "posts" ("array_of_strings","date","datetime","decimal","integer","map","money","multi_money","naive_datetime","string") VALUES ('{hello,world}','2022-04-15','2022-04-15T22:05:37.850495Z',0.12,0,'{"test":true}','(USD, 390)','{"(USD, 230)","(USD, 180)"}','2022-04-15T22:05:37.851978','Post 1') RETURNING "id"
```

Please note that after this change, I started to see the following debug log. Thoughts?

```elixir
[debug] %Postgrex.Query{cache: :statement, columns: nil, name: "ecto_insert_posts_0", param_formats: nil, param_oids: nil, param_types: nil, ref: nil, result_formats: nil, result_oids: nil, result_types: nil, statement: "INSERT INTO \"posts\" (\"array_of_strings\",\"date\",\"datetime\",\"decimal\",\"integer\",\"map\",\"money\",\"multi_money\",\"naive_datetime\",\"string\") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING \"id\"", types: nil} uses unknown oid(s) 563461, 563462forcing us to reload type information from the database. This is expected behaviour whenever you migrate your database.
```