### PR TITLE
Multiple Repo support

### DIFF
--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -11,8 +11,14 @@ defmodule Ecto.DevLogger do
 
   @doc """
   Attaches `telemetry_handler/4` to application.
+
+  Returns the result from the call to `:telemetry.attach/4` or `:ok` if the repo has default logging enabled.
+
+  ## Options
+
+  * `:log_repo_name` - When truthy will add the repo name into the log
   """
-  @spec install(repo_module :: module()) :: :ok | {:error, :already_exists}
+  @spec install(repo_module :: module(), opts :: Keyword.t()) :: :ok | {:error, :already_exists}
   def install(repo_module, opts \\ []) when is_atom(repo_module) do
     config = repo_module.config()
 
@@ -28,11 +34,19 @@ defmodule Ecto.DevLogger do
     end
   end
 
+  @doc """
+  Detaches a previously attached handler for a given Repo.
+
+  Returns the result from the call to `:telemetry.detach/1`
+  """
   @spec uninstall(repo_module :: module()) :: :ok | {:error, :not_found}
   def uninstall(repo_module) when is_atom(repo_module) do
     :telemetry.detach(handler_id(repo_module))
   end
 
+  @doc """
+  Gets the handler_id for a given Repo.
+  """
   @spec handler_id(repo_module :: module()) :: list()
   def handler_id(repo_module) do
     config = repo_module.config()

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -2,7 +2,45 @@ defmodule Ecto.DevLoggerTest do
   use ExUnit.Case
 
   defmodule Repo do
-    use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :does_not_matter
+    use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :my_test_app
+
+    def get_config() do
+      [
+        telemetry_prefix: [:my_test_app, :repo],
+        otp_app: :my_test_app,
+        timeout: 15_000,
+        migration_timestamps: [type: :naive_datetime_usec],
+        database: "ecto_dev_logger_test",
+        hostname: "localhost",
+        username: "postgres",
+        password: "postgres",
+        port: 5432,
+        log: false,
+        stacktrace: true,
+        pool_size: 10
+      ]
+    end
+  end
+
+  defmodule Repo2 do
+    use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :my_test_app
+
+    def get_config() do
+      [
+        telemetry_prefix: [:my_test_app, :repo2],
+        otp_app: :my_test_app,
+        timeout: 15_000,
+        migration_timestamps: [type: :naive_datetime_usec],
+        database: "ecto_dev_logger_test2",
+        hostname: "localhost",
+        username: "postgres",
+        password: "postgres",
+        port: 5432,
+        log: false,
+        stacktrace: true,
+        pool_size: 10
+      ]
+    end
   end
 
   defmodule Money do
@@ -52,43 +90,11 @@ defmodule Ecto.DevLoggerTest do
   end
 
   setup do
-    Repo.__adapter__().storage_down(config())
-    Repo.__adapter__().storage_up(config())
-    {:ok, _} = Repo.start_link(config())
-
-    Repo.query!("CREATE EXTENSION \"pgcrypto\";")
-
-    Repo.query!("""
-    CREATE TYPE money_type AS (currency char(3), value integer);
-    """)
-
-    Repo.query!("""
-    CREATE TABLE posts (
-      id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
-      string text,
-      "binary" bytea,
-      map jsonb,
-      integer integer,
-      decimal numeric,
-      date date,
-      array_of_strings text[],
-      money money_type,
-      multi_money money_type[],
-      password_digest text,
-      datetime timestamp without time zone NOT NULL,
-      naive_datetime timestamp without time zone NOT NULL
-    )
-    """)
-
-    :telemetry.attach(
-      "ecto.dev_logger",
-      [:my_test_app, :repo, :query],
-      &Ecto.DevLogger.telemetry_handler/4,
-      nil
-    )
+    setup_repo(Repo)
+    Ecto.DevLogger.install(Repo)
 
     on_exit(fn ->
-      Repo.__adapter__().storage_down(config())
+      teardown_repo(Repo)
     end)
   end
 
@@ -159,20 +165,190 @@ defmodule Ecto.DevLoggerTest do
     end
   end
 
-  defp config do
-    [
-      telemetry_prefix: [:my_test_app, :repo],
-      otp_app: :my_test_app,
-      timeout: 15000,
-      migration_timestamps: [type: :naive_datetime_usec],
-      database: "ecto_dev_logger_test",
-      hostname: "localhost",
-      username: "postgres",
-      password: "postgres",
-      port: 5432,
-      log: false,
-      stacktrace: true,
-      pool_size: 10
-    ]
+  test "install returns error from failure to attach " do
+    assert {:error, :already_exists} = Ecto.DevLogger.install(Repo)
+  end
+
+  test "handler_id\1" do
+    assert [:ecto_dev_logger, :my_test_app, :repo] = Ecto.DevLogger.handler_id(Repo)
+  end
+
+  describe "multiple repos" do
+    setup do
+      setup_repo(Repo2)
+
+      on_exit(fn ->
+        teardown_repo(Repo2)
+      end)
+    end
+
+    test "install of second repo works" do
+      assert :ok = Ecto.DevLogger.install(Repo2)
+      repo1_prefix = Repo.config()[:telemetry_prefix]
+      [repo1_handler] = :telemetry.list_handlers(repo1_prefix)
+      repo2_prefix = Repo2.config()[:telemetry_prefix]
+      [repo2_handler] = :telemetry.list_handlers(repo2_prefix)
+      # Confirm that there is a distinct handler ID for each repo
+      assert repo1_handler.id != repo2_handler.id
+    end
+
+    test "logging for two repos, with repo name" do
+      ## Use options to enable logging of repo name on second repo
+      assert :ok = Ecto.DevLogger.install(Repo2, log_repo_name: true)
+
+      # Log some basic queries
+      repo1_log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          %{id: post_id} =
+            Repo.insert!(%Post{
+              datetime: ~U[2022-06-25T14:30:16.639767Z],
+              naive_datetime: ~N[2022-06-25T14:30:16.643949]
+            })
+
+          Repo.get!(Post, post_id)
+          :ok
+        end)
+
+      [
+        repo1_insert_start,
+        repo1_insert_status,
+        repo1_insert_query,
+        repo1_insert_location,
+        repo1_select_start,
+        repo1_select_status,
+        repo1_select_query,
+        repo1_select_location,
+        _close
+      ] = String.split(repo1_log, "\n")
+
+      ## Confirm that the original repo's logging is not changed by the addition of a second repo
+      assert repo1_insert_start == "\e[32m"
+      assert repo1_insert_status =~ ~r/\[debug\] QUERY OK db=\d+\.\d+ms/
+
+      assert repo1_insert_query ==
+               "INSERT INTO \"posts\" (\"datetime\",\"naive_datetime\") VALUES (\e[38;5;31m'2022-06-25T14:30:16.639767Z'\e[32m,\e[38;5;31m'2022-06-25T14:30:16.643949'\e[32m) RETURNING \"id\"\e[90m"
+
+      assert repo1_insert_location =~
+               ~r/↳\ anonymous\ fn\/0\ in\ Ecto\.DevLoggerTest\."test\ multiple\ repos\ logging\ for\ two\ repos,\ with\ repo\ name"\/1,\ at:\ test\/ecto\/dev_logger_test\.exs:[0-9]+/
+
+      assert repo1_select_start == "\e[0m\e[36m"
+
+      assert repo1_select_status =~
+               ~r/\[debug\] QUERY OK source=\e\[34m\"posts\"\e\[36m db=\d+\.\d+ms/
+
+      select_query_regex =
+        (Regex.escape(
+           "SELECT p0.\"id\", p0.\"string\", p0.\"binary\", p0.\"map\", p0.\"integer\", p0.\"decimal\", p0.\"date\", p0.\"array_of_strings\", p0.\"money\", p0.\"multi_money\", p0.\"datetime\", p0.\"naive_datetime\", p0.\"password_digest\" FROM \"posts\" AS p0 WHERE (p0.\"id\" = \e[38;5;31m'"
+         ) <>
+           "[-0-9a-fA-F]+" <>
+           Regex.escape("'\e[36m)\e[90m"))
+        |> Regex.compile!()
+
+      assert repo1_select_query =~ select_query_regex
+
+      assert repo1_select_location =~
+               ~r/↳\ anonymous\ fn\/0\ in\ Ecto\.DevLoggerTest\."test\ multiple\ repos\ logging\ for\ two\ repos,\ with\ repo\ name"\/1,\ at:\ test\/ecto\/dev_logger_test\.exs:[0-9]+/
+
+      repo2_log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          %{id: post_id} =
+            Repo2.insert!(%Post{
+              datetime: ~U[2022-06-25T14:30:16.639767Z],
+              naive_datetime: ~N[2022-06-25T14:30:16.643949]
+            })
+
+          Repo2.get!(Post, post_id)
+          :ok
+        end)
+
+      [
+        repo2_insert_start,
+        repo2_insert_status,
+        repo2_insert_query,
+        repo2_insert_location,
+        repo2_select_start,
+        repo2_select_status,
+        repo2_select_query,
+        repo2_select_location,
+        _close
+      ] = String.split(repo2_log, "\n")
+
+      ## Confirm that the logging remains the same apart from the addition of the repo name in the status line. 
+      assert repo2_insert_start == repo1_insert_start
+
+      assert repo2_insert_status =~
+               ~r/\[debug\] QUERY OK repo=\e\[34mEcto.DevLoggerTest.Repo2\e\[\d+m db=\d+\.\d+ms/
+
+      assert repo2_insert_query == repo1_insert_query
+
+      assert repo2_insert_location =~
+               ~r/↳\ anonymous\ fn\/0\ in\ Ecto\.DevLoggerTest\."test\ multiple\ repos\ logging\ for\ two\ repos,\ with\ repo\ name"\/1,\ at:\ test\/ecto\/dev_logger_test\.exs:[0-9]+/
+
+      assert repo2_select_start == repo1_select_start
+
+      assert repo2_select_status =~
+               ~r/\[debug\] QUERY OK source=\e\[34m\"posts\"\e\[36m repo=\e\[34mEcto.DevLoggerTest.Repo2\e\[\d+m db=\d+\.\d+ms/
+
+      assert repo2_select_query =~ select_query_regex
+
+      assert repo2_select_location =~
+               ~r/↳\ anonymous\ fn\/0\ in\ Ecto\.DevLoggerTest\."test\ multiple\ repos\ logging\ for\ two\ repos,\ with\ repo\ name"\/1,\ at:\ test\/ecto\/dev_logger_test\.exs:[0-9]+/
+    end
+  end
+
+  defp setup_repo(repo_module, log_sql_statements \\ false) do
+    config = repo_module.get_config()
+
+    Application.put_env(:my_test_app, repo_module, config)
+    repo_module.__adapter__().storage_down(config)
+    repo_module.__adapter__().storage_up(config)
+    repo_pid = start_supervised!(repo_module)
+
+    repo_module.query!("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";", [], log: log_sql_statements)
+
+    repo_module.query!(
+      """
+      CREATE TYPE money_type AS (currency char(3), value integer);
+      """,
+      [],
+      log: log_sql_statements
+    )
+
+    repo_module.query!(
+      """
+      CREATE TABLE posts (
+        id uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+        string text,
+        "binary" bytea,
+        map jsonb,
+        integer integer,
+        decimal numeric,
+        date date,
+        array_of_strings text[],
+        money money_type,
+        multi_money money_type[],
+        password_digest text,
+        datetime timestamp without time zone NOT NULL,
+        naive_datetime timestamp without time zone NOT NULL
+      )
+      """,
+      [],
+      log: log_sql_statements
+    )
+
+    ## Swallow the reload warning after changing DB structure.
+    assert ExUnit.CaptureLog.capture_log(fn ->
+             repo_module.query!("SELECT * FROM posts")
+           end) =~
+             "forcing us to reload type information from the database. This is expected behaviour whenever you migrate your database."
+
+    repo_pid
+  end
+
+  defp teardown_repo(repo_module) do
+    Ecto.DevLogger.uninstall(repo_module)
+
+    config = repo_module.get_config()
+    repo_module.__adapter__().storage_down(config)
   end
 end


### PR DESCRIPTION
* Ensure that each call to `telemetry.attach/4` receives a unique handler_id based on the telemetry prefix of the repo.
* `Ecto.DevLogger.install/2` now returns the result from `telemetry.attach/4` allowing users to confirm successful setup.
* Add public `Ecto.DevLogger.uninstall/1` to support calling `telemetry.detach/1` with the correct handler_id.
* Add public `Ecto.DevLogger.handler_id/1` to support introspection of telemetry handler ids.
* Add configuration to allow users to add the repo name into the log to enable distinguishing between queries on different repos.
* Refactor test setup & teardown to support setting up multiple repos.
* Tests for the above
* API Documentation 

Fixes #10 