### PR TITLE
Add config :ignore_metadata to silence log

### DIFF
--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -60,6 +60,13 @@ defmodule Ecto.DevLogger do
   defp schema_migration?(metadata) do
     metadata[:options][:schema_migration] == true
   end
+  
+  defp config_ignore?(config, metadata) do
+    case Keyword.get(config, :ignore_metadata) do
+      ignore_metadata when is_function(ignore_metadata, 1) -> ignore_metadata.(metadata)
+      _ -> false
+    end
+  end
 
   @doc "Telemetry handler which logs queries."
   @spec telemetry_handler(
@@ -69,7 +76,7 @@ defmodule Ecto.DevLogger do
           :telemetry.handler_config()
         ) :: :ok
   def telemetry_handler(_event_name, measurements, metadata, config) do
-    if oban_query?(metadata) or schema_migration?(metadata) do
+    if oban_query?(metadata) or schema_migration?(metadata) or config_ignore?(config, metadata) do
       :ok
     else
       query = String.Chars.to_string(metadata.query)


### PR DESCRIPTION
My use case is that https://github.com/mirego/telemetry_ui emits SQL queries that can be silenced using Ecto log option. But `ecto_dev_logger` uses telemetry events so we need a "generic" way to silence events.

I’m not sure about the naming here (`ignore_metadata`) I’m open to suggestions 😄 

Usage:

```elixir
Ecto.DevLogger.install(MyApp.Repo, ignore_metadata: fn metadata ->
  metadata[:options][:telemetry_ui] === true
end)
```
