### PR TITLE
Support Postgrex.Interval

### DIFF
--- a/lib/ecto/dev_logger/printable_parameter.ex
+++ b/lib/ecto/dev_logger/printable_parameter.ex
@@ -289,6 +289,16 @@ if Code.ensure_loaded?(Postgrex.MACADDR) do
   end
 end
 
+if Code.ensure_loaded?(Postgrex.Interval) do
+  defimpl Ecto.DevLogger.PrintableParameter, for: Postgrex.Interval do
+    def to_expression(struct),
+      do: Postgrex.Interval.to_string(struct) |> Ecto.DevLogger.Utils.in_string_quotes()
+
+    def to_string_literal(struct),
+      do: Postgrex.Interval.to_string(struct)
+  end
+end
+
 if Code.ensure_loaded?(Postgrex.INET) do
   defimpl Ecto.DevLogger.PrintableParameter, for: Postgrex.INET do
     def to_expression(inet) do

--- a/test/ecto/dev_logger/printable_parameter_test.exs
+++ b/test/ecto/dev_logger/printable_parameter_test.exs
@@ -60,6 +60,9 @@ defmodule Ecto.DevLogger.PrintableParameterTest do
     assert to_expression(%Postgrex.INET{address: {127, 0, 0, 1}, netmask: nil}) == "'127.0.0.1'"
     assert to_expression(%Postgrex.MACADDR{address: {8, 1, 43, 5, 7, 9}}) == "'08:01:2B:05:07:09'"
 
+    assert to_expression(%Postgrex.Interval{months: 1, days: 2, secs: 34}) ==
+             "'1 month, 2 days, 34 seconds'"
+
     # List
     assert to_expression([]) == "'{}'"
     assert to_expression([1, 2, 3]) == "'{1,2,3}'"


### PR DESCRIPTION
This pull request adds `PrintableParameter` support for `Postgrex.Interval`, as these parameters were causing `ecto_dev_logger` to choke when I started developing features related to timeseries data. The code introduced is minimal, as there is already a `Postgrex.Interval.to_string/1` func that we can delegate to.