### PR TITLE
SQLite3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,11 @@ defmodule MyApp.Application do
   end
 end
 ```
+
+### Running tests
+
+You need to run a local postgres server for the tests to interact with. This is one way to do it: 
+
+```console
+~$ docker run -p5432:5432 --rm --name ecto_dev_logger_postgres -e POSTGRES_PASSWORD=postgres -d postgres
+```

--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -146,7 +146,7 @@ defmodule Ecto.DevLogger do
       |> Map.new(fn {value, index} -> {index, value} end)
 
     query
-    |> String.split("?")
+    |> String.split(~r{\?(?!")})
     |> Enum.map_reduce(0, fn elem, index ->
       formatted_value =
         case Map.fetch(params_by_index, index) do

--- a/lib/ecto/dev_logger.ex
+++ b/lib/ecto/dev_logger.ex
@@ -139,7 +139,8 @@ defmodule Ecto.DevLogger do
     end)
   end
 
-  def inline_params(query, params, return_to_color, Ecto.Adapters.MyXQL) do
+  def inline_params(query, params, return_to_color, repo_adapter)
+      when repo_adapter in [Ecto.Adapters.MyXQL, Ecto.Adapters.SQLite3] do
     params_by_index =
       params
       |> Enum.with_index()

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -210,39 +210,40 @@ defmodule Ecto.DevLoggerTest do
     @params [
       nil,
       "5f833165-b0d4-4d56-b21f-500d29bd94ae",
-      [["test"]]
+      [["test"]],
+      %Ecto.DevLogger.NumericEnum{integer: 1, atom: true}
     ]
     @return_to_color :yellow
     test "Postgres" do
       assert Ecto.DevLogger.inline_params(
-               "UPDATE \"posts\" SET \"string\" = $1 WHERE \"id\" = $2 AND \"array_of_array_of_string\" = $3 RETURNING \"id\"",
+               "UPDATE \"posts\" SET \"string\" = $1 WHERE \"id\" = $2 AND \"array_of_array_of_string\" = $3 OR \"priority?\" = $4 RETURNING \"id\"",
                @params,
                @return_to_color,
                Ecto.Adapters.Postgres
              ) ==
-               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m RETURNING \"id\""
+               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m OR \"priority?\" = \e[38;5;31m1/*true*/\e[33m RETURNING \"id\""
     end
 
     test "Tds" do
       assert Ecto.DevLogger.inline_params(
-               "UPDATE \"posts\" SET \"string\" = @1 WHERE \"id\" = @2 AND \"array_of_array_of_string\" = @3 RETURNING \"id\"",
+               "UPDATE \"posts\" SET \"string\" = @1 WHERE \"id\" = @2 AND \"array_of_array_of_string\" = @3 OR \"priority?\" = @4 RETURNING \"id\"",
                @params,
                @return_to_color,
                Ecto.Adapters.Tds
              ) ==
-               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m RETURNING \"id\""
+               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m OR \"priority?\" = \e[38;5;31m1/*true*/\e[33m RETURNING \"id\""
     end
 
     test "MySQL" do
       assert to_string(
                Ecto.DevLogger.inline_params(
-                 "UPDATE \"posts\" SET \"string\" = ? WHERE \"id\" = ? AND \"array_of_array_of_string\" = ? RETURNING \"id\"",
+                 "UPDATE \"posts\" SET \"string\" = ? WHERE \"id\" = ? AND \"array_of_array_of_string\" = ? OR \"priority?\" = ? RETURNING \"id\"",
                  @params,
                  @return_to_color,
                  Ecto.Adapters.MyXQL
                )
              ) ==
-               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m RETURNING \"id\""
+               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m OR \"priority?\" = \e[38;5;31m1/*true*/\e[33m RETURNING \"id\""
     end
   end
 

--- a/test/ecto/dev_logger_test.exs
+++ b/test/ecto/dev_logger_test.exs
@@ -245,6 +245,18 @@ defmodule Ecto.DevLoggerTest do
              ) ==
                "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m OR \"priority?\" = \e[38;5;31m1/*true*/\e[33m RETURNING \"id\""
     end
+
+    test "SQLite3" do
+      assert to_string(
+               Ecto.DevLogger.inline_params(
+                 "UPDATE \"posts\" SET \"string\" = ? WHERE \"id\" = ? AND \"array_of_array_of_string\" = ? OR \"priority?\" = ? RETURNING \"id\"",
+                 @params,
+                 @return_to_color,
+                 Ecto.Adapters.SQLite3
+               )
+             ) ==
+               "UPDATE \"posts\" SET \"string\" = \e[38;5;31mNULL\e[33m WHERE \"id\" = \e[38;5;31m'5f833165-b0d4-4d56-b21f-500d29bd94ae'\e[33m AND \"array_of_array_of_string\" = \e[38;5;31m'{{test}}'\e[33m OR \"priority?\" = \e[38;5;31m1/*true*/\e[33m RETURNING \"id\""
+    end
   end
 
   test "install returns error from failure to attach " do


### PR DESCRIPTION
Resolves #35 

I've made the edit suggested in #35 to enable support for the SQLite3 adaptor. 

During testing I also found an issue with column names that end in `?` so I've added a naïve fix for it. Basically it doesn't treat `?` as a placeholder for MySQL or SQLite if it is immediately followed by `"`. This seemed to resolve things in my testing. 

I've also added tests for the above and a small comment in `README.md` to give a hint on starting a local Postgres DB to run the tests against.  
